### PR TITLE
[FIX] csrf 비활성화 되어 있던것 활성화

### DIFF
--- a/src/main/java/com/ll/synergarette/base/security/SecurityConfig.java
+++ b/src/main/java/com/ll/synergarette/base/security/SecurityConfig.java
@@ -17,6 +17,11 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
 import org.springframework.security.web.header.writers.frameoptions.XFrameOptionsHeaderWriter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -57,16 +62,20 @@ public class SecurityConfig {
                                 .logoutUrl("/usr/member/logout")
                                 .logoutSuccessUrl("/")
                 )
+
+                /*
                 .csrf((csrf) -> csrf
                         .ignoringRequestMatchers(new AntPathRequestMatcher("/tui-editor/image-upload"))
-                        .disable()
-                )
-                .cors(AbstractHttpConfigurer::disable)
+//                        .ignoringRequestMatchers(new AntPathRequestMatcher("/delivery/selectAddress"))
+//                        .disable()
+                )*/
+//                .cors(AbstractHttpConfigurer::disable)
 
         ;
 
         return http.build();
     }
+
 
 
     @Bean

--- a/src/main/resources/templates/adm/goods/create.html
+++ b/src/main/resources/templates/adm/goods/create.html
@@ -109,10 +109,18 @@
                                 const formData = new FormData();
                                 formData.append('image', blob);
 
+                                const header = document.querySelector('meta[name="_csrf_header"]').content;
+                                const token = document.querySelector('meta[name="_csrf"]').content;
+
                                 // 2. FileApiController - uploadEditorImage 메서드 호출
                                 const response = await fetch('/tui-editor/image-upload', {
                                     method : 'POST',
                                     body : formData,
+                                    headers: {
+                                        'header': header,
+                                        'X-CSRF-Token': token
+                                        // 바로 X-CSRF-Token에 값을 주는 법!
+                                    }
                                 });
 
                                 // 3. 컨트롤러에서 전달받은 s3에 저장된 파일명

--- a/src/main/resources/templates/adm/links/registerPage.html
+++ b/src/main/resources/templates/adm/links/registerPage.html
@@ -84,10 +84,18 @@
                                 const formData = new FormData();
                                 formData.append('image', blob);
 
+                                const header = document.querySelector('meta[name="_csrf_header"]').content;
+                                const token = document.querySelector('meta[name="_csrf"]').content;
+
                                 // 2. FileApiController - uploadEditorImage 메서드 호출
                                 const response = await fetch('/tui-editor/image-upload', {
                                     method : 'POST',
                                     body : formData,
+                                    headers: {
+                                        'header': header,
+                                        'X-CSRF-Token': token
+                                        // 바로 X-CSRF-Token에 값을 주는 법!
+                                    }
                                 });
 
                                 // 3. 컨트롤러에서 전달받은 s3에 저장된 파일명

--- a/src/main/resources/templates/common/layout.html
+++ b/src/main/resources/templates/common/layout.html
@@ -6,6 +6,10 @@
 <head>
   <title>시너가렛</title>
 
+  <meta name="_csrf" th:content="${_csrf.token}"/>
+  <meta name="_csrf_header" th:content="${_csrf.headerName}"/>
+
+
   <!-- 제이쿼리 불러오기 -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.4/jquery.min.js"></script>
 

--- a/src/main/resources/templates/usr/delivery/addressList.html
+++ b/src/main/resources/templates/usr/delivery/addressList.html
@@ -2,15 +2,11 @@
 
 <head>
     <title>Title</title>
-
 </head>
 
 <body>
 
 <main layout:fragment="main">
-
-
-
 
     <div class="container mx-5">
 
@@ -65,12 +61,21 @@
                 var deliveryAddressId = button.closest('.card').find("input[name='nowDelivery']").val();
                 console.log(deliveryAddressId);
 
+                var token = $("meta[name='_csrf']").attr("content");
+		        var header = $("meta[name='_csrf_header']").attr("content");
+
                 var formData = "nowDelivery=" + deliveryAddressId;
 
                 $.ajax({
                     type: "POST",
                     url: "/delivery/selectAddress",
                     data: formData,
+
+                    beforeSend : function(xhr)
+                    {   /*데이터를 전송하기 전에 헤더에 csrf값을 설정한다*/
+                        xhr.setRequestHeader(header, token);
+                    },
+
                     success: function(response) {
                         // 성공 시 수행할 작업
                         // 현재 창 닫기


### PR DESCRIPTION
restful api를 도입하기 전 스프링 시큐리티를 확인하던 중

restful API를 사용하기 위해서는 csrf가 disable되어 있는것이 맞지만 내가 지금까지 했던 프로젝트는 
타임리프를 사용하여 서버 렌더링 방식으로 프론트엔드를 구현한 경우이기 때문에 csrf를 disable하면 보안상에 문제가 발생할 수 있다는것을 확인했다.

그렇기에 우선 restful API 도입할 때 경로를 설정해서 restful API는 예외처리 하기로 할 생각이고
일단 지금까지의 부분에서 csrf를 다시 활성화하고 이것으로 인해 AJAX나 await fetch 로 인해 post 전송하던 것들이 안되는것들은 직접 토큰을 헤더에 담아서 보내주는것으로 수정했다.

close #1 